### PR TITLE
Fix delNode API call

### DIFF
--- a/lib/modules/nodeserver.js
+++ b/lib/modules/nodeserver.js
@@ -374,7 +374,8 @@ module.exports = {
     }
     try {
       result.message = `${data.address} removed successfully`
-      let results = await isy.handleRequestP(data.profileNum, data, command, true)
+      data.address = addNodePrefix(profileNum, data.address)
+      let results = await isy.handleRequestP(profileNum, data, command, true)
       if (results) {
         if (results.statusCode === 200) {
           let node = await Node.findOneAndRemove({address: data.address})


### PR DESCRIPTION
Correctly processes the removenode message by passing the correct
profile number and prefix the incoming node address with the profile
number.

Signed-off-by: Bob Paauwe <bpaauwe@bobsplace.com>