### PR TITLE
Edev fixes

### DIFF
--- a/lib/modules/nodeserver.js
+++ b/lib/modules/nodeserver.js
@@ -928,21 +928,34 @@ module.exports = {
       logger.info(`${ns.logPrefix} Attempting to delete NodeServer ${ns.name}`)
       mqtt.makeResponse(ns.profileNum, 'delete', {})
       logger.info(`${ns.logPrefix} deleting ${ns.name}'s nodes from ISY.`)
+
       if (ns.type === 'local') {
         var index = config.installedNSTypes.indexOf(ns.name)
         if (index > -1) { config.installedNSTypes.splice(index, 1) }
       }
+
       let nodes1 = await Node.find({profileNum: data.profileNum, isprimary: false })
       for (let node of nodes1) {
-        await this.removenode(data.profileNum, node, 'removenode', false)
+	try {
+          await this.removenode(data.profileNum, node, 'removenode', false)
+	} catch (err) {
+          logger.info(`${ns.logPrefix} Failure deleting node ${node.address}`)
+	}
       }
+
       let nodes2 = await Node.find({profileNum: data.profileNum, isprimary: true })
       for (let node of nodes2) {
-        await this.removenode(data.profileNum, node, 'removenode', false)
+	try {
+          await this.removenode(data.profileNum, node, 'removenode', false)
+	} catch (err) {
+          logger.info(`${ns.logPrefix} Failure deleting node ${node.address}`)
+	}
       }
+
       let results = await isy.handleRequestP(ns.profileNum, {api: 'profiles/ns/' + ns.profileNum + '/connection/remove'}, 'restcall', true)
       if (results.statusCode === 200) {
         NodeServer.findOneAndRemove({ profileNum: ns.profileNum }).exec()
+
         result.message = 'Succesfully removed NodeServer. Restart the admin console.'
         mqtt.delSubscription(ns.profileNum)
         if (ns.type === 'local') {

--- a/lib/modules/nodeserver.js
+++ b/lib/modules/nodeserver.js
@@ -18,6 +18,11 @@ var Node = mongoose.model('Node')
 //var that = this
 
 function addNodePrefix(profileNum, nid) {
+  // Don't add prefix if it has already been added.
+  prefix = 'n' + ('00' + profileNum).slice(-3)
+  if (nid.startsWith(prefix))
+     return nid
+
   return `n${('00' + profileNum).slice(-3)}_${nid}`.slice(0, 20)
 }
 


### PR DESCRIPTION
Fix the bug I introduced in removenode. removenode is called from both the polyinterface code and the delete node server function. However, in the first case, it is called with the base node address and in the second it's called with the prefixed node address. The lack of prefix was causing the first case to fail. To properly fix this I first added a call to add the prefix in removenode, however this causes the second case to fail as you end up with a double prefix. To resolve that, I've changed the helper function that adds the prefix to only add the prefix if it is actually missing.

The second fix addresses cases where the remove node server function aborts early, leaving the Polyglot database in a inconsistent state.  It does this by trapping some of the cases that would the function to abort early, thus allowing the function to run to the end even if some of the early steps fail.