### PR TITLE
Updated Dockerfile to use node10:alpine as base and run node natively

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,18 +1,21 @@
-# Learn something new everyday
+FROM node:10-alpine
 
-FROM debian:stretch
-MAINTAINER e42
-
-# 80 = HTTP, 443 = HTTPS, 3000 = Express server(dev), 4200 = Angular2 (dev)
 EXPOSE 3000
+WORKDIR /opt/polyglot-v2/
 
-RUN apt-get update && apt-get dist-upgrade
-RUN apt-get -qqy install git python3-pip python3-dev python2.7-dev python-pip wget
+RUN apk add --no-cache --virtual .build-deps linux-headers build-base && \
+    apk add --no-cache python3 python3-dev py3-pip bash git ca-certificates wget tzdata openssl && \
+    python3 -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip3 install --upgrade pip setuptools && \
+    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
+    rm -r /root/.cache && \
+    cd /opt && \
+    git clone --depth=1 --single-branch --branch master https://github.com/UniversalDevicesInc/polyglot-v2.git && \
+    cd /opt/polyglot-v2 && \
+    apk del .build-deps
 
-RUN mkdir -p /opt/udi-polyglotv2/
-WORKDIR /opt/udi-polyglotv2/
-RUN wget -q https://github.com/Einstein42/udi-polyglotv2/raw/master/binaries/polyglot-v2-linux-x64.tar.gz
-RUN tar -zxf /opt/udi-polyglotv2/polyglot-v2-linux-x64.tar.gz
+VOLUME /root/.polyglot
 
 # Run Polyglot
-CMD /opt/udi-polyglotv2/polyglot-v2-linux-x64
+CMD npm start

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,6 +13,8 @@ services:
         container_name: polyglotv2
         ports:
          - "3000:3000"
+        volumes:
+         - ./dot-polyglot:/root/.polyglot
         links:
          - mongo
         depends_on:

--- a/docker/dot-polyglot/.env.example
+++ b/docker/dot-polyglot/.env.example
@@ -1,0 +1,45 @@
+# Overrides the IP address Polyglot listens on the local machine.
+# If using Docker, set this to the host machine IP address.
+HOST_IP='192.168.1.2'
+
+# Overrides the binding address.
+BIND_IP=::
+
+# Overrides the Port that Polyglot listens on for its frontend interface.
+#HOST_PORT='3000'
+
+# Overrides the default mode of HTTPS
+#USE_HTTPS=false
+
+# Username used to login to the ISY.
+ISY_USERNAME='admin'
+
+# Password used to login to the ISY. Careful this is clear text, I wouldn't recommend setting this here.
+ISY_PASSWORD='password'
+
+# ISY IP address. This is automatically discovered on the initial run of Polyglot if you are on the same network. If you have multiple you can update it on the settings page of the frontend, or override it here.
+ISY_HOST='192.168.1.3'
+
+# ISY Port
+ISY_PORT='80'
+
+# ISY HTTPS: True/False This isn't fully tested so beware HTTPS at the moment.
+ISY_HTTPS=false
+
+# MQTT Host is the IP address of the host running a MQTT server. This is built in to Polyglot so you won't need this unless you'd prefer an external MQTT server.
+#MQTT_HOST='127.0.0.1'
+
+# MQTT Port is the port used to connect to the MQTT server. Default is 1883
+#MQTT_PORT='1883'
+
+# URI to access MongoDB. You might need this if you have an off-box Mongo instance.
+MONGO_URI='mongodb://mongo:27017/'
+
+# To enable debug logging set the NODE_ENV override to 'development'
+NODE_ENV='development'
+
+# To enable Custom SSL Certificates
+#CUSTOM_SSL=true
+
+# Enable Beta Software Updates
+USE_BETA=true


### PR DESCRIPTION
Updated the Dockerfile to use Alpine Linux instead of Debian Stretch and to use Node 10/Python 3 without relying on downloading binary files--to allow support of any architecture that can run Node 10/Python 3/Alpine Linux -- namely, for me, armv8/aarch64.

Also added an example .env file and updated the `docker-compose.yml` file.

The `docker-compose.yml` file will now mount the `dot-polyglot` directory as `/root/.polyglot` inside the container.

This is related to #62 -- a pre-built binary would still be nice for aarch64/armv8 but is not required using this Dockerfile.