### PR TITLE
Update Dockerfile and docker-compose.yml

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,9 +13,11 @@ RUN apk add --no-cache --virtual .build-deps linux-headers build-base && \
     cd /opt && \
     git clone --depth=1 --single-branch --branch master https://github.com/UniversalDevicesInc/polyglot-v2.git && \
     cd /opt/polyglot-v2 && \
+    npm install && \
     apk del .build-deps
 
 VOLUME /root/.polyglot
+VOLUME /usr/lib/python3.6/site-packages
 
 # Run Polyglot
 CMD npm start

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.4'
 services:
     mongo:
         image: "mongo:latest"
@@ -15,6 +15,7 @@ services:
          - "3000:3000"
         volumes:
          - ./dot-polyglot:/root/.polyglot
+         - polyglot-pkgs:/usr/lib/python3.6/site-packages
         links:
          - mongo
         depends_on:
@@ -25,3 +26,8 @@ services:
          - NODE_ENV=development
          - USEDOCKER=true
         restart: always
+
+
+volumes:
+  polyglot-pkgs:
+


### PR DESCRIPTION
Previous version of Dockerfile did not run `npm install` after cloning the repo.

Also added a volume to persist any python packages that are installed by the nodeservers in case the container is destroyed or recreated.  Previously, the nodeservers would persist but none of their packages would.